### PR TITLE
Add VM connectivity, spoofing verification, session injection, and CS2 update management

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-03-30T18:01:32.723Z for PR creation at branch issue-10-46e076deb7d7 for issue https://github.com/uselessgoddess/research/issues/10

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-03-30T18:01:32.723Z for PR creation at branch issue-10-46e076deb7d7 for issue https://github.com/uselessgoddess/research/issues/10

--- a/RUN_INSTRUCTIONS.md
+++ b/RUN_INSTRUCTIONS.md
@@ -4,7 +4,7 @@
 
 ### Hardware
 - x86_64 CPU with Intel VT-x or AMD-V
-- Recommended: 32 GB RAM for 8+ VMs (each uses ~2 GB)
+- Recommended: 32 GB RAM for 8+ VMs (each uses ~2 GB, ~1.5 GB effective with KSM)
 - GPU for VirtIO-GPU Venus (Mesa 24.2+, kernel 6.13+)
 
 ### Software (host)
@@ -15,19 +15,21 @@
 | qemu-img | (matches QEMU) | Disk overlay creation |
 | virtiofsd | any | Shared filesystem (CS2 binaries) |
 | KVM kernel module | loaded | Hardware virtualization |
+| steamcmd | any | CS2 updates (optional) |
+| genisoimage/mkisofs | any | Cloud-init ISO creation |
 
 ### Install dependencies
 
 **Ubuntu / Debian:**
 ```bash
-sudo apt-get install -y qemu-system-x86 qemu-utils libvirt-daemon-system virtinst virtiofsd
+sudo apt-get install -y qemu-system-x86 qemu-utils libvirt-daemon-system virtinst virtiofsd genisoimage
 sudo systemctl enable --now libvirtd
 sudo modprobe kvm kvm_intel  # or kvm_amd
 ```
 
 **Gentoo:**
 ```bash
-sudo emerge -av app-emulation/qemu app-emulation/libvirt app-emulation/virtiofsd
+sudo emerge -av app-emulation/qemu app-emulation/libvirt app-emulation/virtiofsd dev-libs/cdrtools
 sudo rc-update add libvirtd default
 sudo rc-service libvirtd start
 sudo modprobe kvm kvm_intel  # or kvm_amd
@@ -35,7 +37,7 @@ sudo modprobe kvm kvm_intel  # or kvm_amd
 
 **Arch Linux:**
 ```bash
-sudo pacman -S qemu-full libvirt virtiofsd
+sudo pacman -S qemu-full libvirt virtiofsd cdrtools
 sudo systemctl enable --now libvirtd
 ```
 
@@ -62,12 +64,30 @@ cargo build --release
 
 ### 2. Prepare a base disk image
 
-Download or create a Linux base image (e.g., Ubuntu Server or Arch with OpenBox):
+Download a cloud image and create a cloud-init ISO for automatic provisioning:
+
 ```bash
-# Example: download a cloud image
+# Download base image
+mkdir -p /var/lib/vmctl/base
 wget https://cloud-images.ubuntu.com/jammy/current/jammy-server-cloudimg-amd64.img \
   -O /var/lib/vmctl/base/ubuntu-22.04.qcow2
+
+# Generate cloud-init ISO for automatic VM provisioning
+# This installs qemu-guest-agent, Steam, mesa/Vulkan, OpenBox, and systemd services
+./target/release/worker cloud-init \
+  --output /var/lib/vmctl/base/cloud-init.iso \
+  --vm-name cs2-farm-0 \
+  --user farmuser \
+  --password farmpass
 ```
+
+The cloud-init ISO auto-configures:
+- Farm user with sudo access
+- `qemu-guest-agent` (for host-to-guest communication)
+- Steam + mesa Vulkan drivers
+- X11 + OpenBox (minimal WM)
+- `steam-farm.service` (auto-starts Steam when session files are injected)
+- virtiofs mount point at `/opt/cs2`
 
 ### 3. Create a single VM
 ```bash
@@ -77,7 +97,8 @@ wget https://cloud-images.ubuntu.com/jammy/current/jammy-server-cloudimg-amd64.i
   --cpus 2 \
   --vnc-port 5901 \
   --base-disk /var/lib/vmctl/base/ubuntu-22.04.qcow2 \
-  --disk-dir /var/lib/vmctl/disks
+  --disk-dir /var/lib/vmctl/disks \
+  --virtiofs-source /opt/cs2-shared
 ```
 
 ### 4. Batch-create multiple VMs
@@ -89,7 +110,8 @@ wget https://cloud-images.ubuntu.com/jammy/current/jammy-server-cloudimg-amd64.i
   --ram 2048 \
   --cpus 2 \
   --vnc-start 5901 \
-  --disk-dir /var/lib/vmctl/disks
+  --disk-dir /var/lib/vmctl/disks \
+  --virtiofs-source /opt/cs2-shared
 ```
 
 ### 5. VM lifecycle
@@ -101,7 +123,46 @@ wget https://cloud-images.ubuntu.com/jammy/current/jammy-server-cloudimg-amd64.i
 ./target/release/worker undefine cs2-farm-0   # remove definition
 ```
 
-### 6. Inspect spoofed identity
+### 6. Connect to VMs
+
+#### Ping guest agent
+```bash
+./target/release/worker ga-ping cs2-farm-0
+```
+
+#### Execute commands inside VM
+```bash
+# Run any shell command via guest agent (no SSH needed)
+./target/release/worker ga-exec cs2-farm-0 --cmd "uname -a"
+./target/release/worker ga-exec cs2-farm-0 --cmd "dmidecode -t system"
+./target/release/worker ga-exec cs2-farm-0 --cmd "ip link show"
+```
+
+#### Connect via VNC (for manual testing)
+```bash
+# VNC is on localhost:<vnc_port> (e.g., 5901 for first VM)
+vncviewer localhost:5901
+```
+
+### 7. Verify hardware spoofing
+
+After VM is booted and guest agent is running:
+```bash
+# Verify all spoofed hardware identifiers match inside the VM
+./target/release/worker verify cs2-farm-0
+
+# JSON output for automated checks
+./target/release/worker verify cs2-farm-0 --json
+```
+
+This checks:
+- MAC address (should be real vendor OUI, not QEMU default 52:54:00)
+- SMBIOS manufacturer, product, serial (via `dmidecode`)
+- Disk serial (via `lsblk`)
+- Hypervisor visibility (should be hidden from CPUID)
+- NIC driver (should be `e1000e`, not `virtio-net`)
+
+### 8. Inspect spoofed identity
 ```bash
 ./target/release/worker show-identity cs2-farm-0
 ```
@@ -117,17 +178,64 @@ Output (JSON):
 }
 ```
 
-### 7. With virtiofs (shared CS2 directory)
-```bash
-# On the host, share /opt/cs2 to all VMs:
-./target/release/worker create \
-  --name cs2-vm \
-  --base-disk /var/lib/vmctl/base/ubuntu-22.04.qcow2 \
-  --virtiofs-source /opt/cs2
+### 9. Steam session injection
 
-# Inside the guest:
-sudo mount -t virtiofs cs2 /opt/cs2
+Inject a Steam account for automatic login (no user interaction needed):
+```bash
+# Inject session files into a running VM
+./target/release/worker inject-session cs2-farm-0 \
+  --account mysteamuser \
+  --token "eyJhbGciOi..." \
+  --steam-id 76561198012345678 \
+  --persona "FarmBot"
+
+# Switch to a different account (kills Steam, injects new session, restarts)
+./target/release/worker switch-account cs2-farm-0 \
+  --account otheruser \
+  --token "eyJhbGciOi..." \
+  --steam-id 76561198087654321 \
+  --persona "FarmBot2"
 ```
+
+### 10. CS2 updates
+
+CS2 is shared to all VMs via virtiofs from a single host directory:
+
+```bash
+# Check current CS2 installation status
+./target/release/worker cs2-status --shared-dir /opt/cs2-shared
+
+# Update CS2 (stops CS2 in specified VMs, runs steamcmd, VMs auto-restart)
+./target/release/worker cs2-update \
+  --shared-dir /opt/cs2-shared \
+  --vms cs2-farm-0 --vms cs2-farm-1 --vms cs2-farm-2
+```
+
+The update process:
+1. Acquires a lock file to prevent concurrent updates
+2. Signals VMs to stop CS2 via guest agent
+3. Runs `steamcmd +app_update 730 validate`
+4. Releases lock
+5. VMs auto-restart CS2 via systemd
+
+### 11. virtiofs shared CS2 directory
+
+All VMs share a single CS2 installation from the host:
+```bash
+# Create shared directory on host
+sudo mkdir -p /opt/cs2-shared
+
+# Install CS2 once (or use cs2-update command above)
+steamcmd +force_install_dir /opt/cs2-shared +login anonymous +app_update 730 validate +quit
+
+# VMs auto-mount via /etc/fstab (configured by cloud-init):
+#   cs2 /opt/cs2 virtiofs defaults,nofail 0 0
+```
+
+Benefits:
+- **Storage savings**: ~35 GB shared vs ~280 GB for 8 separate copies
+- **Instant updates**: Update once on host, all VMs see new files immediately
+- **Native performance**: virtiofs has near-native I/O speed
 
 ## Architecture
 
@@ -140,13 +248,35 @@ vmctl (this binary)
 ├── destroy        → virsh destroy (force)
 ├── undefine       → virsh undefine
 ├── list           → virsh list --all
-└── show-identity  → deterministic HW spoofing preview
+├── show-identity  → deterministic HW spoofing preview
+├── verify         → check spoofing inside running VM via guest agent
+├── ga-ping        → test guest agent connectivity
+├── ga-exec        → run shell commands inside VM
+├── inject-session → write Steam session files for auto-login
+├── switch-account → switch VM to different Steam account
+├── cs2-status     → check shared CS2 installation status
+├── cs2-update     → coordinate CS2 updates across VMs
+└── cloud-init     → generate provisioning ISO for new VMs
 ```
+
+### Anti-Detection Features (in generated VM XML)
+
+| Feature | Purpose |
+|---------|---------|
+| `<kvm><hidden state='on'/>` | Hides KVM CPUID leaf |
+| `<feature policy='disable' name='hypervisor'/>` | Removes hypervisor flag from CPUID |
+| `<hyperv><vendor_id value='GenuineIntel'/>` | Spoofs Hyper-V vendor ID |
+| `<vmport state='off'/>` | Disables VMware I/O port |
+| `<memballoon model='none'/>` | Removes memory balloon (VM indicator) |
+| `<smbios mode='sysinfo'/>` | Activates SMBIOS data injection |
+| `<model type='e1000e'/>` | Uses real Intel NIC (not virtio PCI ID 1AF4) |
+| Real OUI MAC addresses | Vendor-specific prefixes (Intel, Realtek, Broadcom) |
+| Realistic SMBIOS | Dell, HP, Lenovo, ASUS system info with proper serials |
 
 ## Next Steps (beyond this PoC)
 
-1. **Inside-VM automation**: cloud-init + systemd service for Steam login, CS2 launch
-2. **VNC/QMP controller**: read VM display, inject keyboard/mouse from the host worker
-3. **shai RPC integration**: connect to central server for account queue, heartbeat
-4. **KSM + memory tuning**: enable kernel same-page merging for multi-VM density
-5. **Venus GPU validation**: test VirtIO-GPU Venus with CS2 at 384×288
+1. **VNC/QMP controller**: Read VM display buffer, inject keyboard/mouse from the host worker for gameplay automation
+2. **shai RPC integration**: Connect to central server for account queue, heartbeat, farm coordination
+3. **KSM + memory tuning**: Enable kernel same-page merging for multi-VM density (~30-50% savings)
+4. **Venus GPU validation**: Test VirtIO-GPU Venus with CS2 at 384×288 Vulkan rendering
+5. **ACPI table patching**: Patch QEMU ACPI tables to remove BOCHS/BXPC strings (hard detection vector)

--- a/poc_impl_plan.md
+++ b/poc_impl_plan.md
@@ -4,26 +4,34 @@
 
 The worker CLI (`vmctl`) manages KVM/QEMU virtual machines for CS2 case farming.
 It runs on any Linux host with KVM support and manages VM lifecycle, hardware spoofing,
-and dependency validation.
+guest connectivity, session injection, and CS2 update coordination.
 
 ### Module Breakdown
 
 - [x] **1. Dependency Checker** (`deps.rs`) — Validate host: QEMU version ≥ 9.2, libvirt, KVM module, virtiofs, qemu-img, required kernel modules.
 - [x] **2. Hardware Spoofing** (`spoof.rs`) — Generate realistic MAC (real OUI), SMBIOS (manufacturer/product/serial), disk serials. Deterministic per-VM seed.
-- [x] **3. VM Config / XML Generation** (`config.rs`) — Produce libvirt-compatible XML from structured Rust types. CPU/RAM, VirtIO-GPU Venus, spoofed identifiers, virtiofs mounts, VNC display.
+- [x] **3. VM Config / XML Generation** (`config.rs`) — Produce libvirt-compatible XML from structured Rust types. CPU/RAM, VirtIO-GPU Venus, spoofed identifiers, virtiofs mounts, VNC display. Enhanced anti-detection: KVM hidden, Hyper-V vendor_id, vmport off, memballoon disabled, smbios sysinfo mode, memory backing for virtiofs.
 - [x] **4. Disk Management** (`disk.rs`) — qcow2 backing store + per-VM overlay creation via `qemu-img`.
 - [x] **5. VM Lifecycle** (`vm.rs`) — Create, start, stop, destroy, list VMs. Wraps `virsh` commands (no libvirt C bindings needed for PoC).
-- [x] **6. CLI Interface** (`main.rs` / `cli.rs`) — Subcommands: `check-deps`, `create`, `start`, `stop`, `destroy`, `list`, `setup`.
-- [x] **7. Unit Tests** — Tests for spoofing determinism, XML generation correctness, dependency version parsing.
+- [x] **6. CLI Interface** (`main.rs`) — Subcommands: `check-deps`, `create`, `start`, `stop`, `destroy`, `list`, `setup`, `verify`, `ga-ping`, `ga-exec`, `inject-session`, `switch-account`, `cs2-status`, `cs2-update`, `cloud-init`.
+- [x] **7. Guest Agent** (`guest_agent.rs`) — QEMU Guest Agent interface via `virsh qemu-agent-command`. Ping, exec, file read/write, network queries. No network required — uses virtio-serial channel.
+- [x] **8. Spoofing Verification** (`verify.rs`) — Verify hardware spoofing inside running VMs via guest agent. Checks MAC, SMBIOS, disk serial, hypervisor visibility, NIC driver.
+- [x] **9. Base Image Setup** (`image.rs`) — Cloud-init configuration generation for automatic VM provisioning. Creates user-data/meta-data with qemu-guest-agent, Steam, mesa/Vulkan, OpenBox, systemd services.
+- [x] **10. CS2 Update Management** (`update.rs`) — Centralized CS2 update strategy using virtiofs shared directory. Lock-based coordination, steamcmd integration, VM notification.
+- [x] **11. Steam Session Injection** (`session.rs`) — Inject Steam session files (config.vdf, loginusers.vdf) via guest agent for automatic login. Refresh token based, no user interaction needed. Account switching support.
+- [x] **12. Unit Tests** — 60 tests covering: spoofing determinism, XML generation, anti-detection features, base64 encoding, VDF generation, cloud-init, update lock lifecycle, verification parsing.
 
 ### Non-goals for this PoC
 - No RPC/server integration (Phase 3)
-- No VNC/QMP automation (Phase 2)
-- No AI inference (Phase 4)
-- No mini-worker inside VM (future: systemd service approach)
+- No VNC framebuffer automation / AI inference (Phase 4)
+- No actual steamcmd execution (requires Steam account)
 
 ### Design Decisions
 - **No libvirt C bindings**: Use `virsh` CLI wrapper for PoC simplicity and portability.
-- **No mini-worker inside VM**: For PoC, manual SSH/VNC. Later: cloud-init + systemd service.
+- **Hybrid approach (no mini-worker)**: Uses QEMU Guest Agent (standard component) + systemd service inside VM, controlled from host. No custom daemon inside guest reduces VAC detection risk.
 - **Deterministic spoofing**: Each VM gets reproducible hardware IDs from a seed (VM name hash).
 - **OS-agnostic**: No hard dependency on specific distro; checks required tools at runtime.
+- **virtiofs for CS2 sharing**: Single CS2 installation on host shared to all VMs via virtiofs (saves ~30GB per VM).
+- **Refresh token injection**: Steam auto-login via refresh tokens written to config.vdf (valid ~200 days).
+- **cloud-init provisioning**: Automated VM setup with all required packages and services.
+- **Anti-detection hardening**: KVM hidden, hypervisor CPUID disabled, Hyper-V vendor_id spoofed, vmport off, memballoon disabled, e1000e NIC (not virtio-net).

--- a/worker/src/config.rs
+++ b/worker/src/config.rs
@@ -15,12 +15,21 @@ pub struct VmConfig {
 
 impl VmConfig {
     /// Produce libvirt-compatible XML domain definition.
+    ///
+    /// Generates anti-detection hardened XML with:
+    /// - KVM hidden, hypervisor CPUID disabled
+    /// - Hyper-V vendor ID spoofed to "GenuineIntel"
+    /// - SMBIOS system info spoofing with sysinfo mode
+    /// - e1000e NIC (not virtio-net, which leaks VM identity)
+    /// - memballoon disabled (its presence signals VM)
+    /// - Memory backing for virtiofs DAX support
+    /// - QEMU guest agent channel for host-to-guest communication
     pub fn to_xml(&self) -> String {
         let virtiofs_xml = match (&self.virtiofs_source, &self.virtiofs_tag) {
             (Some(src), Some(tag)) => format!(
                 r#"
     <filesystem type='mount' accessmode='passthrough'>
-      <driver type='virtiofs'/>
+      <driver type='virtiofs' queue='1024'/>
       <source dir='{src}'/>
       <target dir='{tag}'/>
     </filesystem>"#
@@ -28,23 +37,40 @@ impl VmConfig {
             _ => String::new(),
         };
 
+        // Memory backing is required for virtiofs
+        let memory_backing_xml = if self.virtiofs_source.is_some() {
+            r#"
+  <memoryBacking>
+    <source type='memfd'/>
+    <access mode='shared'/>
+  </memoryBacking>
+"#
+        } else {
+            ""
+        };
+
         format!(
             r#"<domain type='kvm'>
   <name>{name}</name>
   <memory unit='MiB'>{ram}</memory>
   <vcpu placement='static'>{vcpus}</vcpu>
-
+{memory_backing}
   <os>
     <type arch='x86_64' machine='q35'>hvm</type>
+    <smbios mode='sysinfo'/>
     <boot dev='hd'/>
   </os>
 
   <features>
     <acpi/>
     <apic/>
+    <hyperv mode='custom'>
+      <vendor_id state='on' value='GenuineIntel'/>
+    </hyperv>
     <kvm>
       <hidden state='on'/>
     </kvm>
+    <vmport state='off'/>
   </features>
 
   <cpu mode='host-passthrough' check='none'>
@@ -87,12 +113,13 @@ impl VmConfig {
       <target type='virtio' name='org.qemu.guest_agent.0'/>
     </channel>
 
-    <memballoon model='virtio'/>
+    <memballoon model='none'/>
   </devices>
 </domain>"#,
             name = self.name,
             ram = self.ram_mb,
             vcpus = self.vcpus,
+            memory_backing = memory_backing_xml,
             smbios_mfr = xml_escape(&self.hw.smbios_manufacturer),
             smbios_prod = xml_escape(&self.hw.smbios_product),
             smbios_serial = xml_escape(&self.hw.smbios_serial),
@@ -163,6 +190,10 @@ mod tests {
         let xml = sample_config().to_xml();
         assert!(xml.contains("type='virtiofs'"));
         assert!(xml.contains("dir='cs2'"));
+        // virtiofs requires memory backing
+        assert!(xml.contains("<memoryBacking>"));
+        assert!(xml.contains("type='memfd'"));
+        assert!(xml.contains("mode='shared'"));
     }
 
     #[test]
@@ -171,7 +202,9 @@ mod tests {
         cfg.virtiofs_source = None;
         cfg.virtiofs_tag = None;
         let xml = cfg.to_xml();
-        assert!(!xml.contains("virtiofs"));
+        assert!(!xml.contains("type='virtiofs'"));
+        // No memory backing without virtiofs
+        assert!(!xml.contains("<memoryBacking>"));
     }
 
     #[test]
@@ -193,5 +226,38 @@ mod tests {
         // Basic well-formedness: starts and ends correctly
         assert!(xml.starts_with("<domain type='kvm'>"));
         assert!(xml.trim().ends_with("</domain>"));
+    }
+
+    #[test]
+    fn test_xml_contains_smbios_mode() {
+        let xml = sample_config().to_xml();
+        assert!(xml.contains("<smbios mode='sysinfo'/>"));
+    }
+
+    #[test]
+    fn test_xml_contains_hyperv_vendor_id() {
+        let xml = sample_config().to_xml();
+        assert!(xml.contains("<vendor_id state='on' value='GenuineIntel'/>"));
+        assert!(xml.contains("<hyperv mode='custom'>"));
+    }
+
+    #[test]
+    fn test_xml_contains_vmport_off() {
+        let xml = sample_config().to_xml();
+        assert!(xml.contains("<vmport state='off'/>"));
+    }
+
+    #[test]
+    fn test_xml_memballoon_none() {
+        let xml = sample_config().to_xml();
+        // memballoon should be disabled (signals VM presence)
+        assert!(xml.contains("<memballoon model='none'/>"));
+        assert!(!xml.contains("<memballoon model='virtio'/>"));
+    }
+
+    #[test]
+    fn test_xml_virtiofs_queue_size() {
+        let xml = sample_config().to_xml();
+        assert!(xml.contains("queue='1024'"));
     }
 }

--- a/worker/src/guest_agent.rs
+++ b/worker/src/guest_agent.rs
@@ -1,0 +1,418 @@
+//! QEMU Guest Agent interface via `virsh qemu-agent-command`.
+//!
+//! Provides typed wrappers around the JSON-based guest-agent protocol
+//! for executing commands, transferring files, and querying VM state
+//! without requiring network connectivity inside the guest.
+
+use serde::{Deserialize, Serialize};
+use std::process::Command;
+
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum GuestAgentError {
+    #[error("guest agent not responding for VM `{0}` (is qemu-guest-agent installed and running?)")]
+    NotResponding(String),
+    #[error("guest-exec failed on VM `{vm}`: {reason}")]
+    ExecFailed { vm: String, reason: String },
+    #[error("file operation failed on VM `{vm}`: {reason}")]
+    FileError { vm: String, reason: String },
+    #[error("virsh command failed: {0}")]
+    Virsh(String),
+    #[error("invalid JSON response: {0}")]
+    Json(String),
+}
+
+/// Result of a command executed inside the guest.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ExecResult {
+    pub exit_code: i32,
+    pub stdout: String,
+    pub stderr: String,
+}
+
+/// Network interface information from the guest.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GuestInterface {
+    pub name: String,
+    pub hardware_address: String,
+    pub ip_addresses: Vec<String>,
+}
+
+/// Send a raw guest-agent command via virsh and return the JSON response.
+fn ga_command(vm_name: &str, json_cmd: &str) -> Result<String, GuestAgentError> {
+    let output = Command::new("virsh")
+        .args(["qemu-agent-command", vm_name, json_cmd])
+        .output()
+        .map_err(|e| GuestAgentError::Virsh(e.to_string()))?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr).to_string();
+        if stderr.contains("agent is not connected")
+            || stderr.contains("Guest agent is not responding")
+            || stderr.contains("QEMU guest agent is not connected")
+        {
+            return Err(GuestAgentError::NotResponding(vm_name.to_string()));
+        }
+        return Err(GuestAgentError::Virsh(stderr));
+    }
+    Ok(String::from_utf8_lossy(&output.stdout).to_string())
+}
+
+/// Ping the guest agent to check availability.
+pub fn ping(vm_name: &str) -> Result<bool, GuestAgentError> {
+    let result = ga_command(vm_name, r#"{"execute":"guest-ping"}"#);
+    match result {
+        Ok(_) => Ok(true),
+        Err(GuestAgentError::NotResponding(_)) => Ok(false),
+        Err(e) => Err(e),
+    }
+}
+
+/// Execute a command inside the guest and wait for the result.
+///
+/// Uses `guest-exec` to start the process and `guest-exec-status` to poll
+/// for completion. The command is run as `["/bin/sh", "-c", cmd]` for
+/// shell expansion support.
+pub fn exec(vm_name: &str, cmd: &str) -> Result<ExecResult, GuestAgentError> {
+    // Build guest-exec command with base64-encoded arguments
+    let exec_cmd = serde_json::json!({
+        "execute": "guest-exec",
+        "arguments": {
+            "path": "/bin/sh",
+            "arg": ["-c", cmd],
+            "capture-output": true
+        }
+    });
+
+    let resp = ga_command(vm_name, &exec_cmd.to_string())?;
+    let resp_json: serde_json::Value =
+        serde_json::from_str(&resp).map_err(|e| GuestAgentError::Json(e.to_string()))?;
+
+    let pid = resp_json["return"]["pid"]
+        .as_i64()
+        .ok_or_else(|| GuestAgentError::Json("missing pid in guest-exec response".into()))?;
+
+    // Poll for completion (guest-exec-status)
+    let max_attempts = 60;
+    for _ in 0..max_attempts {
+        let status_cmd = serde_json::json!({
+            "execute": "guest-exec-status",
+            "arguments": { "pid": pid }
+        });
+
+        let status_resp = ga_command(vm_name, &status_cmd.to_string())?;
+        let status_json: serde_json::Value = serde_json::from_str(&status_resp)
+            .map_err(|e| GuestAgentError::Json(e.to_string()))?;
+
+        let ret = &status_json["return"];
+        if ret["exited"].as_bool() == Some(true) {
+            let exit_code = ret["exitcode"].as_i64().unwrap_or(-1) as i32;
+            let stdout = ret["out-data"]
+                .as_str()
+                .map(decode_base64)
+                .unwrap_or_default();
+            let stderr = ret["err-data"]
+                .as_str()
+                .map(decode_base64)
+                .unwrap_or_default();
+
+            return Ok(ExecResult {
+                exit_code,
+                stdout,
+                stderr,
+            });
+        }
+
+        std::thread::sleep(std::time::Duration::from_secs(1));
+    }
+
+    Err(GuestAgentError::ExecFailed {
+        vm: vm_name.to_string(),
+        reason: format!("command did not complete within {max_attempts}s: {cmd}"),
+    })
+}
+
+/// Write a file inside the guest VM using guest-file-open/write/close.
+pub fn write_file(
+    vm_name: &str,
+    guest_path: &str,
+    data: &[u8],
+) -> Result<(), GuestAgentError> {
+    // Open file for writing
+    let open_cmd = serde_json::json!({
+        "execute": "guest-file-open",
+        "arguments": {
+            "path": guest_path,
+            "mode": "w"
+        }
+    });
+    let resp = ga_command(vm_name, &open_cmd.to_string())?;
+    let resp_json: serde_json::Value =
+        serde_json::from_str(&resp).map_err(|e| GuestAgentError::Json(e.to_string()))?;
+
+    let handle = resp_json["return"]
+        .as_i64()
+        .ok_or_else(|| GuestAgentError::Json("missing file handle".into()))?;
+
+    // Write data (base64-encoded)
+    let encoded = encode_base64(data);
+    let write_cmd = serde_json::json!({
+        "execute": "guest-file-write",
+        "arguments": {
+            "handle": handle,
+            "buf-b64": encoded
+        }
+    });
+    ga_command(vm_name, &write_cmd.to_string())?;
+
+    // Close file
+    let close_cmd = serde_json::json!({
+        "execute": "guest-file-close",
+        "arguments": { "handle": handle }
+    });
+    ga_command(vm_name, &close_cmd.to_string())?;
+
+    Ok(())
+}
+
+/// Read a file from inside the guest VM.
+pub fn read_file(vm_name: &str, guest_path: &str) -> Result<Vec<u8>, GuestAgentError> {
+    let open_cmd = serde_json::json!({
+        "execute": "guest-file-open",
+        "arguments": {
+            "path": guest_path,
+            "mode": "r"
+        }
+    });
+    let resp = ga_command(vm_name, &open_cmd.to_string())?;
+    let resp_json: serde_json::Value =
+        serde_json::from_str(&resp).map_err(|e| GuestAgentError::Json(e.to_string()))?;
+
+    let handle = resp_json["return"]
+        .as_i64()
+        .ok_or_else(|| GuestAgentError::Json("missing file handle".into()))?;
+
+    // Read in chunks
+    let mut result = Vec::new();
+    loop {
+        let read_cmd = serde_json::json!({
+            "execute": "guest-file-read",
+            "arguments": {
+                "handle": handle,
+                "count": 65536
+            }
+        });
+        let read_resp = ga_command(vm_name, &read_cmd.to_string())?;
+        let read_json: serde_json::Value = serde_json::from_str(&read_resp)
+            .map_err(|e| GuestAgentError::Json(e.to_string()))?;
+
+        let ret = &read_json["return"];
+        let buf = ret["buf-b64"]
+            .as_str()
+            .map(decode_base64_bytes)
+            .unwrap_or_default();
+        let eof = ret["eof"].as_bool().unwrap_or(true);
+
+        result.extend_from_slice(&buf);
+        if eof {
+            break;
+        }
+    }
+
+    // Close
+    let close_cmd = serde_json::json!({
+        "execute": "guest-file-close",
+        "arguments": { "handle": handle }
+    });
+    ga_command(vm_name, &close_cmd.to_string())?;
+
+    Ok(result)
+}
+
+/// Query network interfaces inside the guest.
+pub fn get_network_interfaces(vm_name: &str) -> Result<Vec<GuestInterface>, GuestAgentError> {
+    let resp = ga_command(
+        vm_name,
+        r#"{"execute":"guest-network-get-interfaces"}"#,
+    )?;
+    let resp_json: serde_json::Value =
+        serde_json::from_str(&resp).map_err(|e| GuestAgentError::Json(e.to_string()))?;
+
+    let ifaces = resp_json["return"]
+        .as_array()
+        .ok_or_else(|| GuestAgentError::Json("expected array of interfaces".into()))?;
+
+    let mut result = Vec::new();
+    for iface in ifaces {
+        let name = iface["name"].as_str().unwrap_or("unknown").to_string();
+        let hw_addr = iface["hardware-address"]
+            .as_str()
+            .unwrap_or("")
+            .to_string();
+
+        let mut ips = Vec::new();
+        if let Some(addrs) = iface["ip-addresses"].as_array() {
+            for addr in addrs {
+                if let Some(ip) = addr["ip-address"].as_str() {
+                    ips.push(ip.to_string());
+                }
+            }
+        }
+
+        result.push(GuestInterface {
+            name,
+            hardware_address: hw_addr,
+            ip_addresses: ips,
+        });
+    }
+    Ok(result)
+}
+
+/// Simple base64 encoding (no external dependency).
+fn encode_base64(data: &[u8]) -> String {
+    const CHARS: &[u8] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+    let mut result = String::with_capacity(data.len().div_ceil(3) * 4);
+    for chunk in data.chunks(3) {
+        let b0 = chunk[0] as u32;
+        let b1 = if chunk.len() > 1 { chunk[1] as u32 } else { 0 };
+        let b2 = if chunk.len() > 2 { chunk[2] as u32 } else { 0 };
+        let triple = (b0 << 16) | (b1 << 8) | b2;
+
+        result.push(CHARS[((triple >> 18) & 0x3F) as usize] as char);
+        result.push(CHARS[((triple >> 12) & 0x3F) as usize] as char);
+        if chunk.len() > 1 {
+            result.push(CHARS[((triple >> 6) & 0x3F) as usize] as char);
+        } else {
+            result.push('=');
+        }
+        if chunk.len() > 2 {
+            result.push(CHARS[(triple & 0x3F) as usize] as char);
+        } else {
+            result.push('=');
+        }
+    }
+    result
+}
+
+/// Decode base64 string to UTF-8 (lossy).
+fn decode_base64(s: &str) -> String {
+    String::from_utf8_lossy(&decode_base64_bytes(s)).to_string()
+}
+
+/// Decode base64 string to bytes.
+fn decode_base64_bytes(s: &str) -> Vec<u8> {
+    fn val(c: u8) -> u8 {
+        match c {
+            b'A'..=b'Z' => c - b'A',
+            b'a'..=b'z' => c - b'a' + 26,
+            b'0'..=b'9' => c - b'0' + 52,
+            b'+' => 62,
+            b'/' => 63,
+            _ => 0,
+        }
+    }
+
+    let bytes: Vec<u8> = s.bytes().filter(|&b| b != b'\n' && b != b'\r').collect();
+    let mut result = Vec::with_capacity(bytes.len() * 3 / 4);
+
+    for chunk in bytes.chunks(4) {
+        if chunk.len() < 2 {
+            break;
+        }
+        let b0 = val(chunk[0]);
+        let b1 = val(chunk[1]);
+        let b2 = if chunk.len() > 2 && chunk[2] != b'=' {
+            val(chunk[2])
+        } else {
+            0
+        };
+        let b3 = if chunk.len() > 3 && chunk[3] != b'=' {
+            val(chunk[3])
+        } else {
+            0
+        };
+
+        result.push((b0 << 2) | (b1 >> 4));
+        if chunk.len() > 2 && chunk[2] != b'=' {
+            result.push((b1 << 4) | (b2 >> 2));
+        }
+        if chunk.len() > 3 && chunk[3] != b'=' {
+            result.push((b2 << 6) | b3);
+        }
+    }
+    result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_base64_roundtrip() {
+        let data = b"Hello, Guest Agent!";
+        let encoded = encode_base64(data);
+        let decoded = decode_base64_bytes(&encoded);
+        assert_eq!(decoded, data);
+    }
+
+    #[test]
+    fn test_base64_empty() {
+        assert_eq!(encode_base64(b""), "");
+        assert_eq!(decode_base64_bytes(""), Vec::<u8>::new());
+    }
+
+    #[test]
+    fn test_base64_padding() {
+        // 1 byte -> 4 chars with 2 padding
+        let encoded = encode_base64(b"A");
+        assert_eq!(encoded, "QQ==");
+        assert_eq!(decode_base64_bytes("QQ=="), b"A");
+
+        // 2 bytes -> 4 chars with 1 padding
+        let encoded = encode_base64(b"AB");
+        assert_eq!(encoded, "QUI=");
+        assert_eq!(decode_base64_bytes("QUI="), b"AB");
+
+        // 3 bytes -> 4 chars, no padding
+        let encoded = encode_base64(b"ABC");
+        assert_eq!(encoded, "QUJD");
+        assert_eq!(decode_base64_bytes("QUJD"), b"ABC");
+    }
+
+    #[test]
+    fn test_exec_result_serialization() {
+        let result = ExecResult {
+            exit_code: 0,
+            stdout: "output".into(),
+            stderr: "".into(),
+        };
+        let json = serde_json::to_string(&result).unwrap();
+        assert!(json.contains("\"exit_code\":0"));
+        let parsed: ExecResult = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed.exit_code, 0);
+        assert_eq!(parsed.stdout, "output");
+    }
+
+    #[test]
+    fn test_guest_interface_serialization() {
+        let iface = GuestInterface {
+            name: "eth0".into(),
+            hardware_address: "00:1b:21:aa:bb:cc".into(),
+            ip_addresses: vec!["192.168.122.100".into()],
+        };
+        let json = serde_json::to_string(&iface).unwrap();
+        let parsed: GuestInterface = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed.name, "eth0");
+        assert_eq!(parsed.ip_addresses.len(), 1);
+    }
+
+    #[test]
+    fn test_base64_known_vectors() {
+        // Standard base64 test vectors
+        assert_eq!(encode_base64(b"Man"), "TWFu");
+        assert_eq!(decode_base64("TWFu"), "Man");
+        assert_eq!(encode_base64(b"Ma"), "TWE=");
+        assert_eq!(decode_base64("TWE="), "Ma");
+    }
+}

--- a/worker/src/image.rs
+++ b/worker/src/image.rs
@@ -1,0 +1,375 @@
+//! Base image preparation and setup for CS2 farming VMs.
+//!
+//! Handles qcow2 base image management including:
+//! - Cloud image download tracking
+//! - NBD-based offline image customization
+//! - cloud-init configuration generation
+//! - Base image metadata
+
+use serde::{Deserialize, Serialize};
+use std::path::Path;
+use std::process::Command;
+
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum ImageError {
+    #[error("command failed ({cmd}): {reason}")]
+    Command { cmd: String, reason: String },
+    #[error("path not found: {0}")]
+    NotFound(String),
+    #[error("I/O error: {0}")]
+    Io(String),
+}
+
+/// Describes the base image and its configuration.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BaseImageConfig {
+    /// Path to the qcow2 base image.
+    pub image_path: String,
+    /// OS type (e.g., "debian-12", "ubuntu-22.04").
+    pub os_type: String,
+    /// Packages to install during image preparation.
+    pub packages: Vec<String>,
+    /// Whether the image has been prepared (packages installed, services configured).
+    pub prepared: bool,
+}
+
+impl Default for BaseImageConfig {
+    fn default() -> Self {
+        Self {
+            image_path: "/var/lib/vmctl/base/cs2-farm-base.qcow2".into(),
+            os_type: "debian-12".into(),
+            packages: default_packages(),
+            prepared: false,
+        }
+    }
+}
+
+/// Default packages required for CS2 farming VM.
+fn default_packages() -> Vec<String> {
+    [
+        "qemu-guest-agent",
+        "steam-installer",
+        "mesa-vulkan-drivers",
+        "xserver-xorg-core",
+        "openbox",
+        "xinit",
+        "pulseaudio",
+        "dmidecode",
+        "lsblk",
+        "curl",
+        "ca-certificates",
+    ]
+    .iter()
+    .map(|s| s.to_string())
+    .collect()
+}
+
+/// Generate cloud-init user-data YAML for automatic VM provisioning.
+///
+/// This creates a cloud-init config that:
+/// - Sets up a farm user
+/// - Installs required packages
+/// - Enables qemu-guest-agent
+/// - Configures auto-login to X11 + OpenBox
+/// - Creates a systemd service for Steam auto-start
+pub fn generate_cloud_init_userdata(farm_user: &str, farm_password: &str) -> String {
+    format!(
+        r#"#cloud-config
+hostname: cs2-farm-vm
+manage_etc_hosts: true
+
+users:
+  - name: {user}
+    groups: [sudo, video, audio, render]
+    shell: /bin/bash
+    lock_passwd: false
+    plain_text_passwd: "{password}"
+    sudo: ALL=(ALL) NOPASSWD:ALL
+
+package_update: true
+packages:
+  - qemu-guest-agent
+  - steam-installer
+  - mesa-vulkan-drivers
+  - xserver-xorg-core
+  - openbox
+  - xinit
+  - pulseaudio
+  - dmidecode
+
+runcmd:
+  # Enable and start guest agent
+  - systemctl enable qemu-guest-agent
+  - systemctl start qemu-guest-agent
+
+  # Create steam launcher script
+  - |
+    cat > /opt/farm/steam-launcher.sh << 'LAUNCHER'
+    #!/bin/bash
+    # Wait for session files to be injected via guest agent
+    while [ ! -f /home/{user}/.steam/steam/config/.ready ]; do
+        sleep 2
+    done
+    rm -f /home/{user}/.steam/steam/config/.ready
+
+    # Launch Steam in silent mode with minimal UI
+    exec steam -silent -no-browser -console \
+        -w 384 -h 288 \
+        +connect_lobby default
+    LAUNCHER
+  - mkdir -p /opt/farm
+  - chmod +x /opt/farm/steam-launcher.sh
+  - chown {user}:{user} /opt/farm/steam-launcher.sh
+
+  # Create systemd service for Steam auto-launch
+  - |
+    cat > /etc/systemd/system/steam-farm.service << 'SERVICE'
+    [Unit]
+    Description=Steam CS2 Farming Session
+    After=network.target display-manager.service
+
+    [Service]
+    Type=simple
+    User={user}
+    Environment=DISPLAY=:0
+    Environment=DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/1000/bus
+    ExecStart=/opt/farm/steam-launcher.sh
+    Restart=on-failure
+    RestartSec=10
+
+    [Install]
+    WantedBy=multi-user.target
+    SERVICE
+  - systemctl daemon-reload
+  - systemctl enable steam-farm.service
+
+  # Auto-start X11 with OpenBox on boot
+  - |
+    cat > /etc/systemd/system/x11-auto.service << 'XSERVICE'
+    [Unit]
+    Description=Auto-start X11 with OpenBox
+    After=systemd-user-sessions.service
+
+    [Service]
+    Type=simple
+    User={user}
+    ExecStart=/usr/bin/startx /usr/bin/openbox-session -- :0 vt7
+    Restart=on-failure
+    RestartSec=5
+
+    [Install]
+    WantedBy=graphical.target
+    XSERVICE
+  - systemctl daemon-reload
+  - systemctl enable x11-auto.service
+
+  # Create virtiofs mount point for shared CS2 installation
+  - mkdir -p /opt/cs2
+  - |
+    echo 'cs2 /opt/cs2 virtiofs defaults,nofail 0 0' >> /etc/fstab
+
+final_message: "CS2 farm VM provisioning complete"
+"#,
+        user = farm_user,
+        password = farm_password,
+    )
+}
+
+/// Generate cloud-init meta-data for a specific VM instance.
+pub fn generate_cloud_init_metadata(vm_name: &str) -> String {
+    format!(
+        r#"instance-id: {name}
+local-hostname: {name}
+"#,
+        name = vm_name
+    )
+}
+
+/// Create a cloud-init ISO (seed image) for VM provisioning.
+///
+/// Generates user-data and meta-data files and packs them into an ISO
+/// using `genisoimage` or `mkisofs`.
+pub fn create_cloud_init_iso(
+    output_path: &str,
+    vm_name: &str,
+    farm_user: &str,
+    farm_password: &str,
+) -> Result<(), ImageError> {
+    let tmp_dir = format!("/tmp/vmctl-cloud-init-{vm_name}");
+    std::fs::create_dir_all(&tmp_dir).map_err(|e| ImageError::Io(e.to_string()))?;
+
+    let userdata = generate_cloud_init_userdata(farm_user, farm_password);
+    let metadata = generate_cloud_init_metadata(vm_name);
+
+    std::fs::write(format!("{tmp_dir}/user-data"), userdata)
+        .map_err(|e| ImageError::Io(e.to_string()))?;
+    std::fs::write(format!("{tmp_dir}/meta-data"), metadata)
+        .map_err(|e| ImageError::Io(e.to_string()))?;
+
+    // Try genisoimage first, fall back to mkisofs
+    let iso_cmd = if which_exists("genisoimage") {
+        "genisoimage"
+    } else {
+        "mkisofs"
+    };
+
+    let output = Command::new(iso_cmd)
+        .args([
+            "-output",
+            output_path,
+            "-volid",
+            "cidata",
+            "-joliet",
+            "-rock",
+            &format!("{tmp_dir}/user-data"),
+            &format!("{tmp_dir}/meta-data"),
+        ])
+        .output()
+        .map_err(|e| ImageError::Command {
+            cmd: iso_cmd.to_string(),
+            reason: e.to_string(),
+        })?;
+
+    // Cleanup temp files
+    let _ = std::fs::remove_dir_all(&tmp_dir);
+
+    if !output.status.success() {
+        return Err(ImageError::Command {
+            cmd: iso_cmd.to_string(),
+            reason: String::from_utf8_lossy(&output.stderr).to_string(),
+        });
+    }
+    Ok(())
+}
+
+/// Resize a qcow2 image.
+pub fn resize_image(image_path: &str, size: &str) -> Result<(), ImageError> {
+    if !Path::new(image_path).exists() {
+        return Err(ImageError::NotFound(image_path.to_string()));
+    }
+
+    let output = Command::new("qemu-img")
+        .args(["resize", image_path, size])
+        .output()
+        .map_err(|e| ImageError::Command {
+            cmd: "qemu-img resize".into(),
+            reason: e.to_string(),
+        })?;
+
+    if !output.status.success() {
+        return Err(ImageError::Command {
+            cmd: "qemu-img resize".into(),
+            reason: String::from_utf8_lossy(&output.stderr).to_string(),
+        });
+    }
+    Ok(())
+}
+
+/// Convert an image to compressed qcow2 format.
+pub fn compress_image(input_path: &str, output_path: &str) -> Result<(), ImageError> {
+    if !Path::new(input_path).exists() {
+        return Err(ImageError::NotFound(input_path.to_string()));
+    }
+
+    let output = Command::new("qemu-img")
+        .args([
+            "convert", "-c", "-O", "qcow2", input_path, output_path,
+        ])
+        .output()
+        .map_err(|e| ImageError::Command {
+            cmd: "qemu-img convert".into(),
+            reason: e.to_string(),
+        })?;
+
+    if !output.status.success() {
+        return Err(ImageError::Command {
+            cmd: "qemu-img convert".into(),
+            reason: String::from_utf8_lossy(&output.stderr).to_string(),
+        });
+    }
+    Ok(())
+}
+
+fn which_exists(cmd: &str) -> bool {
+    Command::new("which")
+        .arg(cmd)
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_default_packages() {
+        let pkgs = default_packages();
+        assert!(pkgs.contains(&"qemu-guest-agent".to_string()));
+        assert!(pkgs.contains(&"steam-installer".to_string()));
+        assert!(pkgs.contains(&"mesa-vulkan-drivers".to_string()));
+        assert!(pkgs.contains(&"openbox".to_string()));
+        assert!(pkgs.contains(&"dmidecode".to_string()));
+    }
+
+    #[test]
+    fn test_cloud_init_userdata_contains_user() {
+        let ud = generate_cloud_init_userdata("farmuser", "secret123");
+        assert!(ud.contains("name: farmuser"));
+        assert!(ud.contains("plain_text_passwd: \"secret123\""));
+        assert!(ud.contains("qemu-guest-agent"));
+        assert!(ud.contains("steam-farm.service"));
+        assert!(ud.contains("steam-launcher.sh"));
+    }
+
+    #[test]
+    fn test_cloud_init_userdata_contains_virtiofs_mount() {
+        let ud = generate_cloud_init_userdata("farmuser", "pass");
+        assert!(ud.contains("/opt/cs2"));
+        assert!(ud.contains("virtiofs"));
+    }
+
+    #[test]
+    fn test_cloud_init_metadata() {
+        let md = generate_cloud_init_metadata("cs2-farm-0");
+        assert!(md.contains("instance-id: cs2-farm-0"));
+        assert!(md.contains("local-hostname: cs2-farm-0"));
+    }
+
+    #[test]
+    fn test_base_image_config_default() {
+        let cfg = BaseImageConfig::default();
+        assert!(!cfg.prepared);
+        assert_eq!(cfg.os_type, "debian-12");
+        assert!(!cfg.packages.is_empty());
+    }
+
+    #[test]
+    fn test_base_image_config_serialization() {
+        let cfg = BaseImageConfig::default();
+        let json = serde_json::to_string(&cfg).unwrap();
+        let parsed: BaseImageConfig = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed.os_type, cfg.os_type);
+        assert_eq!(parsed.packages.len(), cfg.packages.len());
+    }
+
+    #[test]
+    fn test_resize_not_found() {
+        let err = resize_image("/nonexistent/image.qcow2", "30G");
+        assert!(matches!(err, Err(ImageError::NotFound(_))));
+    }
+
+    #[test]
+    fn test_compress_not_found() {
+        let err = compress_image("/nonexistent/input.qcow2", "/tmp/output.qcow2");
+        assert!(matches!(err, Err(ImageError::NotFound(_))));
+    }
+
+    #[test]
+    fn test_cloud_init_userdata_is_valid_yaml_header() {
+        let ud = generate_cloud_init_userdata("user", "pass");
+        assert!(ud.starts_with("#cloud-config\n"));
+    }
+}

--- a/worker/src/main.rs
+++ b/worker/src/main.rs
@@ -1,7 +1,12 @@
 mod config;
 mod deps;
 mod disk;
+mod guest_agent;
+mod image;
+mod session;
 mod spoof;
+mod update;
+mod verify;
 mod vm;
 
 use clap::{Parser, Subcommand};
@@ -120,6 +125,113 @@ enum Commands {
         #[arg(long)]
         virtiofs_source: Option<String>,
     },
+
+    /// Verify hardware spoofing inside a running VM
+    Verify {
+        /// VM name
+        name: String,
+
+        /// Output as JSON
+        #[arg(long)]
+        json: bool,
+    },
+
+    /// Ping the QEMU guest agent inside a VM
+    GaPing {
+        /// VM name
+        name: String,
+    },
+
+    /// Execute a command inside a VM via the guest agent
+    GaExec {
+        /// VM name
+        name: String,
+
+        /// Command to execute
+        #[arg(short, long)]
+        cmd: String,
+    },
+
+    /// Inject a Steam session into a running VM for auto-login
+    InjectSession {
+        /// VM name
+        name: String,
+
+        /// Steam account name
+        #[arg(long)]
+        account: String,
+
+        /// Steam refresh token
+        #[arg(long)]
+        token: String,
+
+        /// Steam ID (64-bit)
+        #[arg(long)]
+        steam_id: String,
+
+        /// Display name
+        #[arg(long, default_value = "FarmBot")]
+        persona: String,
+    },
+
+    /// Switch a VM to a different Steam account
+    SwitchAccount {
+        /// VM name
+        name: String,
+
+        /// Steam account name
+        #[arg(long)]
+        account: String,
+
+        /// Steam refresh token
+        #[arg(long)]
+        token: String,
+
+        /// Steam ID (64-bit)
+        #[arg(long)]
+        steam_id: String,
+
+        /// Display name
+        #[arg(long, default_value = "FarmBot")]
+        persona: String,
+    },
+
+    /// Check CS2 update status
+    Cs2Status {
+        /// Shared CS2 directory
+        #[arg(long, default_value = "/opt/cs2-shared")]
+        shared_dir: String,
+    },
+
+    /// Update CS2 in the shared directory
+    Cs2Update {
+        /// Shared CS2 directory
+        #[arg(long, default_value = "/opt/cs2-shared")]
+        shared_dir: String,
+
+        /// VM names to notify of the update
+        #[arg(long)]
+        vms: Vec<String>,
+    },
+
+    /// Generate cloud-init ISO for VM provisioning
+    CloudInit {
+        /// Output ISO path
+        #[arg(short, long)]
+        output: String,
+
+        /// VM name (used for instance metadata)
+        #[arg(long)]
+        vm_name: String,
+
+        /// Farm user name inside VM
+        #[arg(long, default_value = "farmuser")]
+        user: String,
+
+        /// Farm user password
+        #[arg(long, default_value = "farmpass")]
+        password: String,
+    },
 }
 
 fn main() {
@@ -171,6 +283,31 @@ fn main() {
             &disk_dir,
             virtiofs_source.as_deref(),
         ),
+        Commands::Verify { name, json } => cmd_verify(&name, json),
+        Commands::GaPing { name } => cmd_ga_ping(&name),
+        Commands::GaExec { name, cmd } => cmd_ga_exec(&name, &cmd),
+        Commands::InjectSession {
+            name,
+            account,
+            token,
+            steam_id,
+            persona,
+        } => cmd_inject_session(&name, &account, &token, &steam_id, &persona),
+        Commands::SwitchAccount {
+            name,
+            account,
+            token,
+            steam_id,
+            persona,
+        } => cmd_switch_account(&name, &account, &token, &steam_id, &persona),
+        Commands::Cs2Status { shared_dir } => cmd_cs2_status(&shared_dir),
+        Commands::Cs2Update { shared_dir, vms } => cmd_cs2_update(&shared_dir, &vms),
+        Commands::CloudInit {
+            output,
+            vm_name,
+            user,
+            password,
+        } => cmd_cloud_init(&output, &vm_name, &user, &password),
     }
 }
 
@@ -351,4 +488,143 @@ fn cmd_setup(
         println!();
     }
     println!("Setup complete. {count} VMs created.");
+}
+
+fn cmd_verify(name: &str, json: bool) {
+    let hw = spoof::generate_identity(name);
+    match verify::verify_spoofing(name, &hw) {
+        Ok(report) => {
+            if json {
+                println!("{}", serde_json::to_string_pretty(&report).unwrap());
+            } else {
+                println!("Spoofing verification for VM '{name}':\n");
+                for check in &report.checks {
+                    let status = if check.passed { "✓" } else { "✗" };
+                    println!("  {status} {}", check.component);
+                    if !check.passed {
+                        println!("      expected: {}", check.expected);
+                        println!("      actual:   {}", check.actual);
+                    }
+                }
+                println!();
+                if report.all_passed {
+                    println!("All spoofing checks passed.");
+                } else {
+                    let failed = report.checks.iter().filter(|c| !c.passed).count();
+                    println!("{failed} check(s) failed.");
+                    std::process::exit(1);
+                }
+            }
+        }
+        Err(e) => {
+            eprintln!("Verification failed for VM '{name}': {e}");
+            std::process::exit(1);
+        }
+    }
+}
+
+fn cmd_ga_ping(name: &str) {
+    match guest_agent::ping(name) {
+        Ok(true) => println!("Guest agent is responding in VM '{name}'."),
+        Ok(false) => {
+            println!("Guest agent is NOT responding in VM '{name}'.");
+            std::process::exit(1);
+        }
+        Err(e) => {
+            eprintln!("Error pinging guest agent: {e}");
+            std::process::exit(1);
+        }
+    }
+}
+
+fn cmd_ga_exec(name: &str, cmd: &str) {
+    match guest_agent::exec(name, cmd) {
+        Ok(result) => {
+            if !result.stdout.is_empty() {
+                print!("{}", result.stdout);
+            }
+            if !result.stderr.is_empty() {
+                eprint!("{}", result.stderr);
+            }
+            std::process::exit(result.exit_code);
+        }
+        Err(e) => {
+            eprintln!("Guest exec failed: {e}");
+            std::process::exit(1);
+        }
+    }
+}
+
+fn cmd_inject_session(name: &str, account: &str, token: &str, steam_id: &str, persona: &str) {
+    let sess = session::SteamSession {
+        account_name: account.to_string(),
+        refresh_token: token.to_string(),
+        steam_id: steam_id.to_string(),
+        persona_name: persona.to_string(),
+    };
+    match session::inject_session(name, &sess, None) {
+        Ok(()) => println!("Session injected for account '{account}' in VM '{name}'."),
+        Err(e) => {
+            eprintln!("Session injection failed: {e}");
+            std::process::exit(1);
+        }
+    }
+}
+
+fn cmd_switch_account(name: &str, account: &str, token: &str, steam_id: &str, persona: &str) {
+    let sess = session::SteamSession {
+        account_name: account.to_string(),
+        refresh_token: token.to_string(),
+        steam_id: steam_id.to_string(),
+        persona_name: persona.to_string(),
+    };
+    match session::switch_account(name, &sess, None) {
+        Ok(()) => println!("Switched VM '{name}' to account '{account}'."),
+        Err(e) => {
+            eprintln!("Account switch failed: {e}");
+            std::process::exit(1);
+        }
+    }
+}
+
+fn cmd_cs2_status(shared_dir: &str) {
+    let cfg = update::UpdateConfig {
+        shared_dir: shared_dir.to_string(),
+        lock_file: format!("{shared_dir}/.update.lock"),
+        ..Default::default()
+    };
+    let status = update::check_status(&cfg);
+    println!("{}", serde_json::to_string_pretty(&status).unwrap());
+}
+
+fn cmd_cs2_update(shared_dir: &str, vms: &[String]) {
+    let cfg = update::UpdateConfig {
+        shared_dir: shared_dir.to_string(),
+        lock_file: format!("{shared_dir}/.update.lock"),
+        ..Default::default()
+    };
+
+    println!("Starting CS2 update in {shared_dir}...");
+    match update::perform_update(&cfg, vms) {
+        Ok(output) => {
+            println!("Update completed successfully.");
+            if !output.is_empty() {
+                println!("\nsteamcmd output:\n{output}");
+            }
+        }
+        Err(e) => {
+            eprintln!("Update failed: {e}");
+            std::process::exit(1);
+        }
+    }
+}
+
+fn cmd_cloud_init(output: &str, vm_name: &str, user: &str, password: &str) {
+    match image::create_cloud_init_iso(output, vm_name, user, password) {
+        Ok(()) => println!("Cloud-init ISO created: {output}"),
+        Err(e) => {
+            eprintln!("Failed to create cloud-init ISO: {e}");
+            std::process::exit(1);
+        }
+    }
 }

--- a/worker/src/session.rs
+++ b/worker/src/session.rs
@@ -1,0 +1,231 @@
+//! Steam session injection for automatic login.
+//!
+//! Injects Steam session files (config.vdf, loginusers.vdf) into a VM
+//! via the QEMU Guest Agent, enabling automatic Steam login without
+//! user interaction.
+//!
+//! Two approaches are supported:
+//! 1. **Refresh token injection** (preferred): Write config.vdf with a
+//!    pre-obtained refresh token. Steam auto-logs in on launch.
+//! 2. **Session file copy**: Copy a complete set of Steam config files
+//!    from a reference machine.
+
+use serde::{Deserialize, Serialize};
+
+use crate::guest_agent;
+
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum SessionError {
+    #[error("guest agent error: {0}")]
+    GuestAgent(#[from] guest_agent::GuestAgentError),
+    #[error("session injection failed for VM `{vm}`: {reason}")]
+    Injection { vm: String, reason: String },
+}
+
+/// Steam account session data for injection.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SteamSession {
+    /// Steam account name.
+    pub account_name: String,
+    /// Steam refresh token (long-lived, ~200 days).
+    pub refresh_token: String,
+    /// Steam ID (64-bit).
+    pub steam_id: String,
+    /// Optional persona name for display.
+    pub persona_name: String,
+}
+
+/// Default path to Steam config directory inside the guest.
+const STEAM_CONFIG_DIR: &str = "/home/farmuser/.steam/steam/config";
+
+/// Generate config.vdf content with refresh token for auto-login.
+pub fn generate_config_vdf(session: &SteamSession) -> String {
+    format!(
+        r#""InstallConfigStore"
+{{
+	"Software"
+	{{
+		"Valve"
+		{{
+			"Steam"
+			{{
+				"AutoLoginUser"		"{account}"
+				"Accounts"
+				{{
+					"{account}"
+					{{
+						"SteamID"		"{steam_id}"
+					}}
+				}}
+				"ConnectCache"
+				{{
+					"{account}"
+					{{
+						"Token"		"{token}"
+					}}
+				}}
+			}}
+		}}
+	}}
+}}"#,
+        account = session.account_name,
+        steam_id = session.steam_id,
+        token = session.refresh_token,
+    )
+}
+
+/// Generate loginusers.vdf content for auto-login.
+pub fn generate_loginusers_vdf(session: &SteamSession) -> String {
+    format!(
+        r#""users"
+{{
+	"{steam_id}"
+	{{
+		"AccountName"		"{account}"
+		"PersonaName"		"{persona}"
+		"RememberPassword"		"1"
+		"AllowAutoLogin"		"1"
+		"MostRecent"		"1"
+	}}
+}}"#,
+        steam_id = session.steam_id,
+        account = session.account_name,
+        persona = session.persona_name,
+    )
+}
+
+/// Inject a Steam session into a running VM via the guest agent.
+///
+/// This writes the config.vdf and loginusers.vdf files, then creates
+/// a `.ready` marker file that the steam-launcher service watches for.
+pub fn inject_session(
+    vm_name: &str,
+    session: &SteamSession,
+    config_dir: Option<&str>,
+) -> Result<(), SessionError> {
+    let dir = config_dir.unwrap_or(STEAM_CONFIG_DIR);
+
+    // Ensure config directory exists
+    guest_agent::exec(vm_name, &format!("mkdir -p {dir}"))?;
+
+    // Write config.vdf
+    let config_vdf = generate_config_vdf(session);
+    guest_agent::write_file(
+        vm_name,
+        &format!("{dir}/config.vdf"),
+        config_vdf.as_bytes(),
+    )?;
+
+    // Write loginusers.vdf
+    let loginusers_vdf = generate_loginusers_vdf(session);
+    guest_agent::write_file(
+        vm_name,
+        &format!("{dir}/loginusers.vdf"),
+        loginusers_vdf.as_bytes(),
+    )?;
+
+    // Write .ready marker for the steam-launcher service
+    guest_agent::write_file(vm_name, &format!("{dir}/.ready"), b"1")?;
+
+    Ok(())
+}
+
+/// Switch a VM to a different Steam account.
+///
+/// 1. Kills Steam process
+/// 2. Injects new session files
+/// 3. Triggers Steam restart via systemd
+pub fn switch_account(
+    vm_name: &str,
+    session: &SteamSession,
+    config_dir: Option<&str>,
+) -> Result<(), SessionError> {
+    // Kill existing Steam process
+    let kill_result = guest_agent::exec(vm_name, "pkill -TERM -f steam || true");
+    if let Err(e) = kill_result {
+        eprintln!("Warning: could not kill Steam in VM '{vm_name}': {e}");
+    }
+
+    // Wait for Steam to exit
+    std::thread::sleep(std::time::Duration::from_secs(3));
+
+    // Inject new session
+    inject_session(vm_name, session, config_dir)?;
+
+    // Restart the Steam farming service
+    guest_agent::exec(vm_name, "systemctl --user restart steam-farm.service || true")?;
+
+    Ok(())
+}
+
+/// Check if Steam is currently running inside a VM.
+pub fn is_steam_running(vm_name: &str) -> Result<bool, SessionError> {
+    let result = guest_agent::exec(vm_name, "pgrep -c steam 2>/dev/null || echo 0")?;
+    let count: i32 = result.stdout.trim().parse().unwrap_or(0);
+    Ok(count > 0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample_session() -> SteamSession {
+        SteamSession {
+            account_name: "testuser123".into(),
+            refresh_token: "eyJhbGciOiJFZERTQSJ9.test_token_data".into(),
+            steam_id: "76561198012345678".into(),
+            persona_name: "TestPlayer".into(),
+        }
+    }
+
+    #[test]
+    fn test_config_vdf_generation() {
+        let session = sample_session();
+        let vdf = generate_config_vdf(&session);
+        assert!(vdf.contains("\"AutoLoginUser\"\t\t\"testuser123\""));
+        assert!(vdf.contains("\"SteamID\"\t\t\"76561198012345678\""));
+        assert!(vdf.contains("\"Token\"\t\t\"eyJhbGciOiJFZERTQSJ9.test_token_data\""));
+    }
+
+    #[test]
+    fn test_loginusers_vdf_generation() {
+        let session = sample_session();
+        let vdf = generate_loginusers_vdf(&session);
+        assert!(vdf.contains("\"AccountName\"\t\t\"testuser123\""));
+        assert!(vdf.contains("\"PersonaName\"\t\t\"TestPlayer\""));
+        assert!(vdf.contains("\"RememberPassword\"\t\t\"1\""));
+        assert!(vdf.contains("\"AllowAutoLogin\"\t\t\"1\""));
+        assert!(vdf.contains("\"76561198012345678\""));
+    }
+
+    #[test]
+    fn test_session_serialization() {
+        let session = sample_session();
+        let json = serde_json::to_string(&session).unwrap();
+        let parsed: SteamSession = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed.account_name, "testuser123");
+        assert_eq!(parsed.steam_id, "76561198012345678");
+    }
+
+    #[test]
+    fn test_config_vdf_structure() {
+        let session = sample_session();
+        let vdf = generate_config_vdf(&session);
+        // Verify VDF structure has proper nesting
+        assert!(vdf.starts_with("\"InstallConfigStore\""));
+        assert!(vdf.contains("\"Software\""));
+        assert!(vdf.contains("\"Valve\""));
+        assert!(vdf.contains("\"Steam\""));
+        assert!(vdf.contains("\"ConnectCache\""));
+    }
+
+    #[test]
+    fn test_loginusers_vdf_structure() {
+        let session = sample_session();
+        let vdf = generate_loginusers_vdf(&session);
+        assert!(vdf.starts_with("\"users\""));
+        assert!(vdf.contains("\"MostRecent\"\t\t\"1\""));
+    }
+}

--- a/worker/src/update.rs
+++ b/worker/src/update.rs
@@ -1,0 +1,278 @@
+//! CS2 update management across VMs.
+//!
+//! Implements the centralized update strategy using virtiofs:
+//! - One shared CS2 installation on the host (`/opt/cs2-shared/`)
+//! - All VMs mount it read-only via virtiofs
+//! - Updates are performed by stopping VMs, running steamcmd on host,
+//!   then restarting VMs
+//!
+//! The update coordinator uses a lock file to prevent concurrent updates.
+
+use std::path::Path;
+use std::process::Command;
+
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+use crate::guest_agent;
+
+#[derive(Debug, Error)]
+pub enum UpdateError {
+    #[error("update already in progress (lock: {0})")]
+    LockExists(String),
+    #[error("shared directory not found: {0}")]
+    SharedDirNotFound(String),
+    #[error("steamcmd failed: {0}")]
+    SteamCmd(String),
+    #[error("I/O error: {0}")]
+    Io(String),
+    #[error("guest agent error: {0}")]
+    GuestAgent(String),
+}
+
+impl From<guest_agent::GuestAgentError> for UpdateError {
+    fn from(e: guest_agent::GuestAgentError) -> Self {
+        UpdateError::GuestAgent(e.to_string())
+    }
+}
+
+/// CS2 update configuration.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct UpdateConfig {
+    /// Host path to the shared CS2 installation.
+    pub shared_dir: String,
+    /// Path to the lock file during updates.
+    pub lock_file: String,
+    /// Steam login for steamcmd (anonymous for CS2).
+    pub steam_login: String,
+    /// CS2 app ID.
+    pub app_id: u32,
+}
+
+impl Default for UpdateConfig {
+    fn default() -> Self {
+        Self {
+            shared_dir: "/opt/cs2-shared".into(),
+            lock_file: "/opt/cs2-shared/.update.lock".into(),
+            steam_login: "anonymous".into(),
+            app_id: 730,
+        }
+    }
+}
+
+/// Status of the CS2 installation.
+#[derive(Debug, Clone, Serialize)]
+pub struct Cs2Status {
+    pub installed: bool,
+    pub shared_dir: String,
+    pub update_in_progress: bool,
+    pub manifest_exists: bool,
+}
+
+/// Check the current status of the shared CS2 installation.
+pub fn check_status(config: &UpdateConfig) -> Cs2Status {
+    let shared_exists = Path::new(&config.shared_dir).is_dir();
+    let lock_exists = Path::new(&config.lock_file).exists();
+    let manifest = format!(
+        "{}/steamapps/appmanifest_{}.acf",
+        config.shared_dir, config.app_id
+    );
+    let manifest_exists = Path::new(&manifest).exists();
+
+    Cs2Status {
+        installed: shared_exists && manifest_exists,
+        shared_dir: config.shared_dir.clone(),
+        update_in_progress: lock_exists,
+        manifest_exists,
+    }
+}
+
+/// Acquire the update lock. Returns error if another update is in progress.
+pub fn acquire_lock(config: &UpdateConfig) -> Result<(), UpdateError> {
+    if Path::new(&config.lock_file).exists() {
+        return Err(UpdateError::LockExists(config.lock_file.clone()));
+    }
+    let content = format!(
+        "pid={}\nstarted={}",
+        std::process::id(),
+        chrono_now_fallback()
+    );
+    std::fs::write(&config.lock_file, content).map_err(|e| UpdateError::Io(e.to_string()))?;
+    Ok(())
+}
+
+/// Release the update lock.
+pub fn release_lock(config: &UpdateConfig) -> Result<(), UpdateError> {
+    if Path::new(&config.lock_file).exists() {
+        std::fs::remove_file(&config.lock_file).map_err(|e| UpdateError::Io(e.to_string()))?;
+    }
+    Ok(())
+}
+
+/// Run steamcmd to update CS2 in the shared directory.
+///
+/// This should be called after all VMs have been stopped or have
+/// unmounted the shared directory.
+pub fn run_steamcmd_update(config: &UpdateConfig) -> Result<String, UpdateError> {
+    if !Path::new(&config.shared_dir).is_dir() {
+        std::fs::create_dir_all(&config.shared_dir)
+            .map_err(|e| UpdateError::Io(e.to_string()))?;
+    }
+
+    let output = Command::new("steamcmd")
+        .args([
+            "+force_install_dir",
+            &config.shared_dir,
+            "+login",
+            &config.steam_login,
+            &format!("+app_update {} validate", config.app_id),
+            "+quit",
+        ])
+        .output()
+        .map_err(|e| UpdateError::SteamCmd(e.to_string()))?;
+
+    let stdout = String::from_utf8_lossy(&output.stdout).to_string();
+    let stderr = String::from_utf8_lossy(&output.stderr).to_string();
+
+    if !output.status.success() {
+        return Err(UpdateError::SteamCmd(format!(
+            "exit code: {:?}\nstderr: {stderr}",
+            output.status.code()
+        )));
+    }
+
+    Ok(stdout)
+}
+
+/// Notify a running VM to restart CS2 after an update.
+///
+/// Uses guest agent to kill the CS2 process and let the systemd
+/// service restart it automatically.
+pub fn notify_vm_restart_cs2(vm_name: &str) -> Result<(), UpdateError> {
+    // Kill CS2 process; systemd will auto-restart it
+    guest_agent::exec(vm_name, "pkill -TERM -f cs2 || true")?;
+    Ok(())
+}
+
+/// Perform a full update cycle:
+/// 1. Acquire lock
+/// 2. Notify VMs to stop CS2
+/// 3. Run steamcmd update
+/// 4. Release lock
+/// 5. Notify VMs to restart CS2
+pub fn perform_update(
+    config: &UpdateConfig,
+    vm_names: &[String],
+) -> Result<String, UpdateError> {
+    // Step 1: Lock
+    acquire_lock(config)?;
+
+    // Step 2: Stop CS2 in all VMs
+    for vm in vm_names {
+        if let Err(e) = notify_vm_restart_cs2(vm) {
+            eprintln!("Warning: could not stop CS2 in VM '{vm}': {e}");
+        }
+    }
+
+    // Step 3: Update
+    let result = run_steamcmd_update(config);
+
+    // Step 4: Always release lock
+    let _ = release_lock(config);
+
+    let output = result?;
+
+    // Step 5: VMs will auto-restart CS2 via systemd
+
+    Ok(output)
+}
+
+/// Simple timestamp without chrono dependency.
+fn chrono_now_fallback() -> String {
+    let output = Command::new("date")
+        .arg("+%Y-%m-%dT%H:%M:%S%z")
+        .output();
+    match output {
+        Ok(o) => String::from_utf8_lossy(&o.stdout).trim().to_string(),
+        Err(_) => "unknown".to_string(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_update_config_default() {
+        let cfg = UpdateConfig::default();
+        assert_eq!(cfg.shared_dir, "/opt/cs2-shared");
+        assert_eq!(cfg.app_id, 730);
+        assert_eq!(cfg.steam_login, "anonymous");
+    }
+
+    #[test]
+    fn test_check_status_nonexistent() {
+        let cfg = UpdateConfig {
+            shared_dir: "/nonexistent/cs2-shared".into(),
+            lock_file: "/nonexistent/.lock".into(),
+            ..Default::default()
+        };
+        let status = check_status(&cfg);
+        assert!(!status.installed);
+        assert!(!status.update_in_progress);
+        assert!(!status.manifest_exists);
+    }
+
+    #[test]
+    fn test_cs2_status_serialization() {
+        let status = Cs2Status {
+            installed: true,
+            shared_dir: "/opt/cs2".into(),
+            update_in_progress: false,
+            manifest_exists: true,
+        };
+        let json = serde_json::to_string(&status).unwrap();
+        assert!(json.contains("\"installed\":true"));
+        assert!(json.contains("\"update_in_progress\":false"));
+    }
+
+    #[test]
+    fn test_lock_lifecycle() {
+        let tmp = std::env::temp_dir().join("vmctl-test-lock");
+        let lock_path = tmp.to_str().unwrap().to_string();
+
+        // Clean up from previous runs
+        let _ = std::fs::remove_file(&lock_path);
+
+        let cfg = UpdateConfig {
+            lock_file: lock_path.clone(),
+            ..Default::default()
+        };
+
+        // Acquire should succeed
+        assert!(acquire_lock(&cfg).is_ok());
+        assert!(Path::new(&lock_path).exists());
+
+        // Double acquire should fail
+        assert!(matches!(
+            acquire_lock(&cfg),
+            Err(UpdateError::LockExists(_))
+        ));
+
+        // Release should succeed
+        assert!(release_lock(&cfg).is_ok());
+        assert!(!Path::new(&lock_path).exists());
+
+        // Release on non-existent is ok
+        assert!(release_lock(&cfg).is_ok());
+    }
+
+    #[test]
+    fn test_update_config_serialization() {
+        let cfg = UpdateConfig::default();
+        let json = serde_json::to_string(&cfg).unwrap();
+        let parsed: UpdateConfig = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed.app_id, 730);
+        assert_eq!(parsed.shared_dir, "/opt/cs2-shared");
+    }
+}

--- a/worker/src/verify.rs
+++ b/worker/src/verify.rs
@@ -1,0 +1,297 @@
+//! Hardware spoofing verification inside VMs.
+//!
+//! Uses the QEMU Guest Agent to run diagnostic commands inside the VM
+//! and compare the results against the expected spoofed identity.
+
+use crate::guest_agent;
+use crate::spoof::HwIdentity;
+
+use serde::Serialize;
+
+/// Result of a single spoofing check.
+#[derive(Debug, Clone, Serialize)]
+pub struct SpoofCheck {
+    pub component: String,
+    pub expected: String,
+    pub actual: String,
+    pub passed: bool,
+}
+
+/// Full verification report for a VM.
+#[derive(Debug, Clone, Serialize)]
+pub struct VerifyReport {
+    pub vm_name: String,
+    pub checks: Vec<SpoofCheck>,
+    pub all_passed: bool,
+}
+
+/// Commands to run inside the guest for hardware verification.
+struct VerifyCmd {
+    component: &'static str,
+    command: &'static str,
+    extract: fn(&str) -> String,
+}
+
+/// Extract the first non-empty trimmed line from command output.
+fn first_line(output: &str) -> String {
+    output
+        .lines()
+        .map(str::trim)
+        .find(|l| !l.is_empty())
+        .unwrap_or("")
+        .to_string()
+}
+
+/// Extract MAC address from `ip link show` output.
+///
+/// Looks for lines containing `link/ether` and extracts the MAC.
+fn extract_mac(output: &str) -> String {
+    for line in output.lines() {
+        let trimmed = line.trim();
+        if trimmed.starts_with("link/ether") {
+            return trimmed
+                .split_whitespace()
+                .nth(1)
+                .unwrap_or("")
+                .to_string();
+        }
+    }
+    String::new()
+}
+
+/// Extract disk serial from `lsblk` output.
+///
+/// Parses `lsblk -o NAME,SERIAL -n` format.
+fn extract_disk_serial(output: &str) -> String {
+    for line in output.lines() {
+        let trimmed = line.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+        let parts: Vec<&str> = trimmed.split_whitespace().collect();
+        if parts.len() >= 2 {
+            // Return the serial (second column) for the first disk found
+            return parts[1].to_string();
+        }
+    }
+    String::new()
+}
+
+/// Extract a dmidecode field value from its output.
+///
+/// Looks for lines like `\tManufacturer: Dell Inc.` and returns the value.
+fn extract_dmidecode_field(output: &str, field: &str) -> String {
+    for line in output.lines() {
+        let trimmed = line.trim();
+        if let Some(rest) = trimmed.strip_prefix(field) {
+            let rest = rest.trim_start_matches(':').trim();
+            return rest.to_string();
+        }
+    }
+    String::new()
+}
+
+/// Verify hardware spoofing for a running VM by comparing guest-visible
+/// hardware identifiers against the expected spoofed identity.
+///
+/// Requires:
+/// - VM is running
+/// - `qemu-guest-agent` is installed and active inside the guest
+/// - Guest has `ip`, `lsblk`, and `dmidecode` commands available
+pub fn verify_spoofing(
+    vm_name: &str,
+    expected: &HwIdentity,
+) -> Result<VerifyReport, guest_agent::GuestAgentError> {
+    // First check that the guest agent is responding
+    let alive = guest_agent::ping(vm_name)?;
+    if !alive {
+        return Err(guest_agent::GuestAgentError::NotResponding(
+            vm_name.to_string(),
+        ));
+    }
+
+    let mut checks = Vec::new();
+
+    // 1. MAC address check
+    let mac_result = guest_agent::exec(vm_name, "ip link show 2>/dev/null")?;
+    let actual_mac = extract_mac(&mac_result.stdout);
+    checks.push(SpoofCheck {
+        component: "MAC Address".into(),
+        expected: expected.mac_address.clone(),
+        actual: actual_mac.clone(),
+        passed: actual_mac.eq_ignore_ascii_case(&expected.mac_address),
+    });
+
+    // 2. SMBIOS manufacturer
+    let dmi_system =
+        guest_agent::exec(vm_name, "dmidecode -t system 2>/dev/null || echo ''")?;
+    let actual_mfr = extract_dmidecode_field(&dmi_system.stdout, "Manufacturer");
+    checks.push(SpoofCheck {
+        component: "SMBIOS Manufacturer".into(),
+        expected: expected.smbios_manufacturer.clone(),
+        actual: actual_mfr.clone(),
+        passed: actual_mfr == expected.smbios_manufacturer,
+    });
+
+    // 3. SMBIOS product name
+    let actual_product = extract_dmidecode_field(&dmi_system.stdout, "Product Name");
+    checks.push(SpoofCheck {
+        component: "SMBIOS Product".into(),
+        expected: expected.smbios_product.clone(),
+        actual: actual_product.clone(),
+        passed: actual_product == expected.smbios_product,
+    });
+
+    // 4. SMBIOS serial
+    let actual_serial = extract_dmidecode_field(&dmi_system.stdout, "Serial Number");
+    checks.push(SpoofCheck {
+        component: "SMBIOS Serial".into(),
+        expected: expected.smbios_serial.clone(),
+        actual: actual_serial.clone(),
+        passed: actual_serial == expected.smbios_serial,
+    });
+
+    // 5. Disk serial
+    let disk_result =
+        guest_agent::exec(vm_name, "lsblk -o NAME,SERIAL -n 2>/dev/null || echo ''")?;
+    let actual_disk_serial = extract_disk_serial(&disk_result.stdout);
+    checks.push(SpoofCheck {
+        component: "Disk Serial".into(),
+        expected: expected.disk_serial.clone(),
+        actual: actual_disk_serial.clone(),
+        passed: actual_disk_serial == expected.disk_serial,
+    });
+
+    // 6. Hypervisor visibility check (should NOT detect hypervisor)
+    let cpuid_result = guest_agent::exec(
+        vm_name,
+        "grep -c hypervisor /proc/cpuinfo 2>/dev/null || echo 0",
+    )?;
+    let hypervisor_visible = first_line(&cpuid_result.stdout) != "0";
+    checks.push(SpoofCheck {
+        component: "Hypervisor Hidden".into(),
+        expected: "hidden (0)".into(),
+        actual: if hypervisor_visible {
+            "visible".into()
+        } else {
+            "hidden (0)".into()
+        },
+        passed: !hypervisor_visible,
+    });
+
+    // 7. NIC model check (should be e1000e, not virtio-net)
+    let nic_result = guest_agent::exec(
+        vm_name,
+        "ls /sys/class/net/*/device/driver 2>/dev/null | head -5 || echo ''",
+    )?;
+    let nic_output = nic_result.stdout.trim().to_string();
+    let uses_e1000e = nic_output.contains("e1000e");
+    checks.push(SpoofCheck {
+        component: "NIC Driver (e1000e)".into(),
+        expected: "e1000e".into(),
+        actual: if uses_e1000e {
+            "e1000e".into()
+        } else {
+            nic_output
+        },
+        passed: uses_e1000e,
+    });
+
+    let all_passed = checks.iter().all(|c| c.passed);
+
+    Ok(VerifyReport {
+        vm_name: vm_name.to_string(),
+        checks,
+        all_passed,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_extract_mac() {
+        let output = r#"2: enp1s0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc fq_codel state UP mode DEFAULT group default qlen 1000
+    link/ether 3c:97:0e:ab:cd:ef brd ff:ff:ff:ff:ff:ff"#;
+        assert_eq!(extract_mac(output), "3c:97:0e:ab:cd:ef");
+    }
+
+    #[test]
+    fn test_extract_mac_empty() {
+        assert_eq!(extract_mac("no ether here"), "");
+    }
+
+    #[test]
+    fn test_extract_disk_serial() {
+        let output = "vda   WDC12345678\nsda   \n";
+        assert_eq!(extract_disk_serial(output), "WDC12345678");
+    }
+
+    #[test]
+    fn test_extract_disk_serial_empty() {
+        assert_eq!(extract_disk_serial("vda\n"), "");
+    }
+
+    #[test]
+    fn test_extract_dmidecode_field() {
+        let output = r#"System Information
+	Manufacturer: Dell Inc.
+	Product Name: OptiPlex 7080
+	Version: Not Specified
+	Serial Number: SVC1234567"#;
+        assert_eq!(
+            extract_dmidecode_field(output, "Manufacturer"),
+            "Dell Inc."
+        );
+        assert_eq!(
+            extract_dmidecode_field(output, "Product Name"),
+            "OptiPlex 7080"
+        );
+        assert_eq!(
+            extract_dmidecode_field(output, "Serial Number"),
+            "SVC1234567"
+        );
+    }
+
+    #[test]
+    fn test_extract_dmidecode_missing_field() {
+        assert_eq!(extract_dmidecode_field("nothing here", "Manufacturer"), "");
+    }
+
+    #[test]
+    fn test_first_line() {
+        assert_eq!(first_line("hello\nworld"), "hello");
+        assert_eq!(first_line("\n\nfoo"), "foo");
+        assert_eq!(first_line(""), "");
+    }
+
+    #[test]
+    fn test_spoof_check_serialization() {
+        let check = SpoofCheck {
+            component: "MAC".into(),
+            expected: "00:11:22:33:44:55".into(),
+            actual: "00:11:22:33:44:55".into(),
+            passed: true,
+        };
+        let json = serde_json::to_string(&check).unwrap();
+        assert!(json.contains("\"passed\":true"));
+    }
+
+    #[test]
+    fn test_verify_report_serialization() {
+        let report = VerifyReport {
+            vm_name: "test-vm".into(),
+            checks: vec![SpoofCheck {
+                component: "MAC".into(),
+                expected: "aa:bb:cc:dd:ee:ff".into(),
+                actual: "aa:bb:cc:dd:ee:ff".into(),
+                passed: true,
+            }],
+            all_passed: true,
+        };
+        let json = serde_json::to_string_pretty(&report).unwrap();
+        assert!(json.contains("\"all_passed\": true"));
+        assert!(json.contains("test-vm"));
+    }
+}


### PR DESCRIPTION
## 🤖 AI-Powered Solution Draft

Fixes uselessgoddess/research#10

## Summary

Implements Phase 2 of the worker — connecting to VMs and managing them end-to-end for CS2 farming:

- **Guest Agent connectivity** (`guest_agent.rs`): QEMU Guest Agent interface via `virsh qemu-agent-command`. Ping, exec commands, read/write files, query network — all without network inside the guest (uses virtio-serial channel).

- **Hardware spoofing verification** (`verify.rs`): Verifies that spoofed identifiers (MAC, SMBIOS, disk serial, hypervisor hidden, NIC driver) match inside the running VM. New `vmctl verify <vm>` command with JSON output.

- **Base image provisioning** (`image.rs`): Cloud-init configuration that auto-installs qemu-guest-agent, Steam, mesa/Vulkan, OpenBox, and creates systemd services for Steam auto-launch. New `vmctl cloud-init` command.

- **Steam session injection** (`session.rs`): Writes config.vdf / loginusers.vdf with refresh tokens into the VM via guest agent for zero-interaction Steam login. Supports account switching. New `vmctl inject-session` and `vmctl switch-account` commands.

- **CS2 update management** (`update.rs`): Centralized update via virtiofs shared directory. Lock-based coordination, steamcmd integration, VM notification. New `vmctl cs2-status` and `vmctl cs2-update` commands.

- **Enhanced anti-detection** in VM XML: Hyper-V vendor_id=GenuineIntel, vmport off, memballoon=none (VM indicator), smbios sysinfo mode, memory backing for virtiofs DAX, virtiofs queue=1024.

### New CLI Commands

| Command | Description |
|---------|-------------|
| `verify <vm>` | Verify hardware spoofing inside running VM |
| `ga-ping <vm>` | Test guest agent connectivity |
| `ga-exec <vm> --cmd "..."` | Run shell command inside VM |
| `inject-session <vm>` | Inject Steam session for auto-login |
| `switch-account <vm>` | Switch VM to different Steam account |
| `cs2-status` | Check shared CS2 installation status |
| `cs2-update` | Coordinate CS2 update across VMs |
| `cloud-init` | Generate provisioning ISO |

### Anti-Detection Improvements

| Feature | Purpose |
|---------|---------|
| `<hyperv><vendor_id value='GenuineIntel'/>` | Spoofs Hyper-V vendor ID |
| `<vmport state='off'/>` | Disables VMware I/O port |
| `<memballoon model='none'/>` | Removes VM indicator |
| `<smbios mode='sysinfo'/>` | Activates SMBIOS data injection |
| Memory backing (memfd + shared) | Required for virtiofs DAX |

## Test plan
- [x] `cargo check` passes (no compilation errors)
- [x] `cargo clippy` passes (no clippy warnings from new code)
- [x] `cargo test` passes — 60 unit tests covering all modules:
  - Base64 encoding/decoding roundtrip
  - VDF file generation (config.vdf, loginusers.vdf)
  - Cloud-init YAML generation
  - XML anti-detection features (smbios mode, hyperv vendor_id, vmport, memballoon=none)
  - XML memory backing for virtiofs
  - Update lock lifecycle
  - Spoofing verification parsing (MAC, dmidecode, disk serial)
  - Serialization of all data structures

🤖 Generated with [Claude Code](https://claude.com/claude-code)